### PR TITLE
fix: update category name from 'Backend' to 'Development' in Courses …

### DIFF
--- a/frontend/src/pages/Courses.jsx
+++ b/frontend/src/pages/Courses.jsx
@@ -192,7 +192,7 @@ const Courses = () => {
   const categories = [
     "All",
     "Frontend",
-    "Backend",
+    "Development",
     "Full Stack",
     "Data Science",
     "AI/ML",


### PR DESCRIPTION
…page